### PR TITLE
Replace manual RCS_PATH variable with automatic detection using RiotClientInstalls.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,32 +24,7 @@ NOTE: Antivirus/Windows Defender might mark the executable as a **potentially un
 
 3. Copy the path to the executable for a later step
     - if the folder was made under "C:\Program Files\valorant-rpc", the path would be "C:\Program Files\valorant-rpc\valorant-rpc.exe"
-
-### Part 2: Finding the RiotClientServices.exe path
-1. Search for the installation location of RiotClientServices.exe
-    - it is typically installed in C:\Riot Games\Riot Client\
-    - ex. C:\Riot Games\Riot Client\RiotClientServices.exe
-2. Copy the path for the next part
-
-### Part 3: Creating the system environment variable for RiotClientServices.exe path
-Creating this system variable will allow the extension to launch VALORANT
-1. In the **Windows Search Bar**, search for "environment" and select the *Edit the system environment variables* option
-
-![image](https://user-images.githubusercontent.com/42125428/109581495-61ef7e80-7aca-11eb-82aa-0566caf33e3f.png)
-
-2. In the **System Properties** window, select *Environment Variables*
-
-![image](https://user-images.githubusercontent.com/42125428/109581512-69168c80-7aca-11eb-9eb2-8b8bb2e6f2ab.png)
-
-3. In the **Environment Variables** window, select *New* under *System variables*
-
-![image](https://user-images.githubusercontent.com/42125428/109581530-6f0c6d80-7aca-11eb-95de-05ce21f5e1a8.png)
-
-4. Using the path copied in [part 2, step 2](https://github.com/colinhartigan/valorant-rich-presence/blob/main/README.md#part-2-finding-the-riotclientservicesexe-path), create a new system variable called **RCS_PATH** and click *OK*
-
-![image](https://user-images.githubusercontent.com/42125428/109582065-7718dd00-7acb-11eb-9476-121bb0de9c4c.png)
-
-### Part 4: Changing the VALORANT launch target
+### Part 2: Changing the VALORANT launch target
 
 1. Locate the VALORANT shortcut
     - if you typically launch from your desktop, locate the VALORANT icon

--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ if __name__=="__main__":
     #check if val is open
     if not is_process_running():
         print("valorant not opened, attempting to run...")
-        subprocess.Popen([os.environ['RCS_PATH'], "--launch-product=valorant", "--launch-patchline=live"])
+        subprocess.Popen([utils.get_rcs_path(), "--launch-product=valorant", "--launch-patchline=live"])
         while not is_process_running():
             print("waiting for valorant...")
             launch_timer += 1

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
 import iso8601
+import os
+import json
 
 maps = {
     "Port":"Icebox",
@@ -36,5 +38,16 @@ def parse_time(time):
     split = iso8601.parse_date(split).timestamp()
     return split
 
+def get_rcs_path():
+    RIOT_CLIENT_INSTALLS_PATH = os.path.expandvars("%PROGRAMDATA%\\Riot Games\\RiotClientInstalls.json")
+    try:
+        with open(RIOT_CLIENT_INSTALLS_PATH, "r") as file:
+            client_installs = json.load(file)
+            rcs_path = os.path.abspath(client_installs["rc_default"])
+            if not os.access(rcs_path, os.X_OK):
+                return None
+            return rcs_path
+    except FileNotFoundError:
+        return None
 
 validate_party_size = lambda data : data["isPartyOwner"] == True and data["partySize"] > 1

--- a/utils.py
+++ b/utils.py
@@ -39,6 +39,8 @@ def parse_time(time):
     return split
 
 def get_rcs_path():
+    """Attempts to use the RiotClientInstalls.json file to detect the location of RiotClientServices.
+    Returns the absolute path if found or None if not."""
     RIOT_CLIENT_INSTALLS_PATH = os.path.expandvars("%PROGRAMDATA%\\Riot Games\\RiotClientInstalls.json")
     try:
         with open(RIOT_CLIENT_INSTALLS_PATH, "r") as file:


### PR DESCRIPTION
I added the `get_rcs_path()` method I wrote for [urwrstkn8mare/galaxy-riot-integration](https://github.com/urwrstkn8mare/galaxy-riot-integration) to `utils.py` to get the RiotClientServices install path using the location found in the `%PROGRAMDATA%\Riot Games\RiotClientInstalls.json` file.

This removes the need for the user to manually create a `RCS_PATH` environment variable, greatly simplifying the setup process for the program which I have also removed from the README.