### PR TITLE
🐛 Fix config.

### DIFF
--- a/data/blank_config.json
+++ b/data/blank_config.json
@@ -7,10 +7,10 @@
 		"ingame_refresh_interval": 3,
 		"debug": false
 	},
-    "region": "na",
+    	"region": "na",
 	"rpc-oauth": {},
 	"rpc-client-override": {
 		"client_id": "811469787657928704",
 		"client_secret": ""
-	},
+	}
 }


### PR DESCRIPTION
Fixed config because you forgot to delete ``,`` after moving ``region`` variable higher, and now it will not create config nor read it because JSON parser will throw errors.
![image](https://user-images.githubusercontent.com/9348108/114366138-71f38700-9b7b-11eb-86f9-9f3a9f042f7e.png)
