### PR TITLE
consistent menu presences

### DIFF
--- a/src/presence/presences/menu_presences/away.py
+++ b/src/presence/presences/menu_presences/away.py
@@ -12,7 +12,7 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
         details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
         state=f"{Localizer.get_localized_text('presences','client_states','away')} (" + party_state + ")",
         large_image="game_icon_yellow",
-        large_text="VALORANT",
+        large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
         small_image=small_image,
         small_text=small_text,
     )

--- a/src/presence/presences/menu_presences/away.py
+++ b/src/presence/presences/menu_presences/away.py
@@ -4,11 +4,22 @@ from ...presence_utilities import Utilities
 def presence(rpc,client=None,data=None,content_data=None,config=None):
     _, mode_name = Utilities.fetch_mode_data(data,content_data)
     
+    small_image, mode_name = Utilities.fetch_mode_data(data,content_data)
+    small_text = mode_name
     party_state,party_size = Utilities.build_party_state(data)
     if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
         small_image, small_text = Utilities.fetch_rank_data(client,content_data)
-    
-    rpc.update(
+        
+        rpc.update(
+        details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
+        state=f"{Localizer.get_localized_text('presences','client_states','away')} (" + party_state + ")",
+        large_image="game_icon_yellow",
+        large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
+        small_image=small_image,
+        small_text=small_text,
+    )
+    else:
+        rpc.update(
         details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
         state=f"{Localizer.get_localized_text('presences','client_states','away')} (" + party_state + ")",
         large_image="game_icon_yellow",

--- a/src/presence/presences/menu_presences/away.py
+++ b/src/presence/presences/menu_presences/away.py
@@ -18,13 +18,4 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
         small_image=small_image,
         small_text=small_text,
     )
-    else:
-        rpc.update(
-        details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
-        state=f"{Localizer.get_localized_text('presences','client_states','away')} (" + party_state + ")",
-        large_image="game_icon_yellow",
-        large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
-        small_image=small_image,
-        small_text=small_text,
-    )
     

--- a/src/presence/presences/menu_presences/away.py
+++ b/src/presence/presences/menu_presences/away.py
@@ -3,9 +3,17 @@ from ...presence_utilities import Utilities
 
 def presence(rpc,client=None,data=None,content_data=None,config=None):
     _, mode_name = Utilities.fetch_mode_data(data,content_data)
+    
+    party_state,party_size = Utilities.build_party_state(data)
+    if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
+        small_image, small_text = Utilities.fetch_rank_data(client,content_data)
+    
     rpc.update(
-        details=f"{mode_name}",
-        state=f"{Localizer.get_localized_text('presences','client_states','away')}",
+        details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
+        state=f"{Localizer.get_localized_text('presences','client_states','away')} (" + party_state + ")",
         large_image="game_icon_yellow",
         large_text="VALORANT",
+        small_image=small_image,
+        small_text=small_text,
     )
+    

--- a/src/presence/presences/menu_presences/default.py
+++ b/src/presence/presences/menu_presences/default.py
@@ -28,15 +28,3 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
             party_id=data["partyId"],
             buttons=buttons
         )
-        else:
-            rpc.update(
-            state=party_state,
-            details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
-            large_image="game_icon",
-            large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
-            small_image=small_image,
-            small_text=small_text,
-            party_size=party_size,
-            party_id=data["partyId"],
-            buttons=buttons
-        )

--- a/src/presence/presences/menu_presences/default.py
+++ b/src/presence/presences/menu_presences/default.py
@@ -11,13 +11,25 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
     else:
         party_state,party_size = Utilities.build_party_state(data)
         small_image, mode_name = Utilities.fetch_mode_data(data,content_data)
-        small_text = None
+        small_text = mode_name
         buttons = Utilities.get_join_state(client,config,data)
 
         if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
             small_image, small_text = Utilities.fetch_rank_data(client,content_data)
 
-        rpc.update(
+            rpc.update(
+            state=party_state,
+            details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
+            large_image="game_icon",
+            large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
+            small_image=small_image,
+            small_text=small_text,
+            party_size=party_size,
+            party_id=data["partyId"],
+            buttons=buttons
+        )
+        else:
+            rpc.update(
             state=party_state,
             details=f"{Localizer.get_localized_text('presences','client_states','menu')} - {mode_name}",
             large_image="game_icon",

--- a/src/presence/presences/menu_presences/queue.py
+++ b/src/presence/presences/menu_presences/queue.py
@@ -6,6 +6,10 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
     party_state,party_size = Utilities.build_party_state(data)
     start_time = Utilities.iso8601_to_epoch(data['queueEntryTime'])
     small_image, mode_name = Utilities.fetch_mode_data(data, content_data)
+    
+    if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
+        small_image, small_text = Utilities.fetch_rank_data(client,content_data)
+    
     rpc.update(
         state=party_state,
         details=f"{Localizer.get_localized_text('presences','client_states','queue')} - {mode_name}",

--- a/src/presence/presences/menu_presences/queue.py
+++ b/src/presence/presences/menu_presences/queue.py
@@ -6,17 +6,31 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
     party_state,party_size = Utilities.build_party_state(data)
     start_time = Utilities.iso8601_to_epoch(data['queueEntryTime'])
     small_image, mode_name = Utilities.fetch_mode_data(data, content_data)
+    small_text = mode_name
     
     if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
         small_image, small_text = Utilities.fetch_rank_data(client,content_data)
-    
-    rpc.update(
+        
+        rpc.update(
         state=party_state,
         details=f"{Localizer.get_localized_text('presences','client_states','queue')} - {mode_name}",
         start=start_time,
         large_image="game_icon_white",
         large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
         small_image=small_image,
+        small_text=small_text,
+        party_size=party_size,
+        party_id=data["partyId"],
+    )
+    else:
+        rpc.update(
+        state=party_state,
+        details=f"{Localizer.get_localized_text('presences','client_states','queue')} - {mode_name}",
+        start=start_time,
+        large_image="game_icon_white",
+        large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
+        small_image=small_image,
+        small_text=small_text,
         party_size=party_size,
         party_id=data["partyId"],
     )

--- a/src/presence/presences/menu_presences/queue.py
+++ b/src/presence/presences/menu_presences/queue.py
@@ -22,15 +22,3 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
         party_size=party_size,
         party_id=data["partyId"],
     )
-    else:
-        rpc.update(
-        state=party_state,
-        details=f"{Localizer.get_localized_text('presences','client_states','queue')} - {mode_name}",
-        start=start_time,
-        large_image="game_icon_white",
-        large_text=f"{Localizer.get_localized_text('presences','leveling','level')} {data['accountLevel']}",
-        small_image=small_image,
-        small_text=small_text,
-        party_size=party_size,
-        party_id=data["partyId"],
-    )

--- a/src/presence/presences/pregame.py
+++ b/src/presence/presences/pregame.py
@@ -22,18 +22,31 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
         agent_image, agent_name = Utilities.fetch_agent_data(pregame_player_data["CharacterID"],content_data)
         select_state = Localizer.get_localized_text("presences","pregame","locked") if pregame_player_data["CharacterSelectionState"] == "locked" else Localizer.get_localized_text("presences","pregame","selecting")
         small_image, mode_name = Utilities.fetch_mode_data(data,content_data)
+        small_text = mode_name
 
         if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
             small_image, small_text = Utilities.fetch_rank_data(client,content_data)
-    
-        rpc.update(
+
+            rpc.update(
             state=party_state,
             details=f"{Localizer.get_localized_text('presences','client_states','pregame')} - {mode_name}",
             end=pregame_end_time,
             large_image=agent_image,
             large_text=f"{select_state} - {agent_name}",
             small_image=small_image,
-            small_text=mode_name,
+            small_text=small_text,
+            party_size=party_size,
+            party_id=data["partyId"],
+        )
+        else:
+            rpc.update(
+            state=party_state,
+            details=f"{Localizer.get_localized_text('presences','client_states','pregame')} - {mode_name}",
+            end=pregame_end_time,
+            large_image=agent_image,
+            large_text=f"{select_state} - {agent_name}",
+            small_image=small_image,
+            small_text=small_text,
             party_size=party_size,
             party_id=data["partyId"],
         )

--- a/src/presence/presences/pregame.py
+++ b/src/presence/presences/pregame.py
@@ -23,6 +23,9 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
         select_state = Localizer.get_localized_text("presences","pregame","locked") if pregame_player_data["CharacterSelectionState"] == "locked" else Localizer.get_localized_text("presences","pregame","selecting")
         small_image, mode_name = Utilities.fetch_mode_data(data,content_data)
 
+        if data["queueId"] == "competitive" and Localizer.get_config_value("presences","menu","show_rank_in_comp_lobby"): 
+            small_image, small_text = Utilities.fetch_rank_data(client,content_data)
+    
         rpc.update(
             state=party_state,
             details=f"{Localizer.get_localized_text('presences','client_states','pregame')} - {mode_name}",

--- a/src/presence/presences/pregame.py
+++ b/src/presence/presences/pregame.py
@@ -38,17 +38,5 @@ def presence(rpc,client=None,data=None,content_data=None,config=None):
             party_size=party_size,
             party_id=data["partyId"],
         )
-        else:
-            rpc.update(
-            state=party_state,
-            details=f"{Localizer.get_localized_text('presences','client_states','pregame')} - {mode_name}",
-            end=pregame_end_time,
-            large_image=agent_image,
-            large_text=f"{select_state} - {agent_name}",
-            small_image=small_image,
-            small_text=small_text,
-            party_size=party_size,
-            party_id=data["partyId"],
-        )
     except PhaseError:
         pass

--- a/src/presence/presences/startup.py
+++ b/src/presence/presences/startup.py
@@ -3,7 +3,7 @@ from ...localization.localization import Localizer
 def presence(rpc,client=None,data=None,content_data=None,config=None):
     rpc.update(
         state=Localizer.get_localized_text("presences","startup","loading"),
-        large_image="game_icon",
+        large_image="game_icon_white",
         large_text="VALORANT-rpc",
         buttons=[{
             'label':Localizer.get_localized_text("presences","startup","view_github"),


### PR DESCRIPTION
competitive lobbies should now show rank throughout queue/pregame states and when away instead of only when idle (plus I think it looks overall nicer)