### PR TITLE
websockets & PyInstaller -> requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psutil
 Flask
 InquirerPy
 Pillow
+PyInstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Flask
 InquirerPy
 Pillow
 PyInstaller
+websockets


### PR DESCRIPTION
For the building process, both websockets and PyInstaller are required. 